### PR TITLE
[Bugfix] RuntimeError: There is no current event loop in thread

### DIFF
--- a/TikTokAPI/tiktok_browser.py
+++ b/TikTokAPI/tiktok_browser.py
@@ -51,7 +51,7 @@ class TikTokBrowser:
         self.tiktok_dummy_page = "file://" + os.path.join(parent_folder, "website", "tiktok.html")
 
     def fetch_auth_params(self, url, language='en'):
-        return asyncio.get_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
+        return asyncio.new_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
 
     async def async_fetch_auth_params(self, url, language):
         browser = await launch(self.options)


### PR DESCRIPTION
```
RuntimeError: There is no current event loop in thread 'ThreadPoolExecutor-0_0'
    TRACEBACK:
    Traceback (most recent call last):
  ...
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/TikTokAPI/tiktokapi.py", line 239, in downloadVideoById
    video_info = self.getVideoById(video_id)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/TikTokAPI/tiktokapi.py", line 236, in getVideoById
    return self.send_get_request(url, params)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/TikTokAPI/tiktokapi.py", line 74, in send_get_request
    signature = self.tiktok_browser.fetch_auth_params(url, language=self.language)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/TikTokAPI/tiktok_browser.py", line 54, in fetch_auth_params
    return asyncio.get_event_loop().run_until_complete(self.async_fetch_auth_params(url, language))
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/events.py", line 656, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
```


In tests, it used to show up like: `DeprecationWarning: There is no current event loop`
